### PR TITLE
[Form] IE11 - CSS rule is incorrect for input placeholders.

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -323,7 +323,7 @@
   color: @inputPlaceholderColor;
 }
 .ui.form :-ms-input-placeholder {
-  color: @inputPlaceholderColor;
+  color: @inputPlaceholderColor !important;
 }
 .ui.form ::-moz-placeholder {
   color: @inputPlaceholderColor;
@@ -333,7 +333,7 @@
   color: @inputPlaceholderFocusColor;
 }
 .ui.form :focus:-ms-input-placeholder {
-  color: @inputPlaceholderFocusColor;
+  color: @inputPlaceholderFocusColor !important;
 }
 .ui.form :focus::-moz-placeholder {
   color: @inputPlaceholderFocusColor;


### PR DESCRIPTION
Fixes Semantic-Org/Semantic-UI#6363