### PR TITLE
[Segment] A basic segment within .segments should be basic

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -470,7 +470,9 @@
        Basic
 --------------------*/
 
-.ui.basic.segment {
+.ui.basic.segment,
+.ui.segments .ui.basic.segment,
+.ui.basic.segments {
   background: @basicBackground;
   box-shadow: @basicBoxShadow;
   border: @basicBorder;


### PR DESCRIPTION
This PR try to fix a problem and add a new functionality :

- The fix : when we have a `.ui.basic.segment` inside of `.ui.horizontal.segments`, the basic segment doesn't loose the border and shadow.

- The new functionality : Add a `.ui.basic.segments` with **s**
It comes in handy when we want to do something like this
```css
.ui.horizontal.basic.segments>(.ui.basic.segment+.ui.basic.right.aligned.segment)
```

Edit: This is an example from my app

Before the PR
Jsfiddle example : https://jsfiddle.net/h4nycLoj/
![image](https://cloud.githubusercontent.com/assets/1449151/20519654/0ef94610-b0a4-11e6-99ea-2b4680f9d45a.png)

After the PR

![image](https://cloud.githubusercontent.com/assets/1449151/20519578/c4253ebe-b0a3-11e6-83d9-c1561b1f2509.png)

The markup used in the images

```html
<div class="ui horizontal basic segments"> <!-- New functionality -->
    <div class="ui basic segment"> ... </div><!-- Fixed: basic segment shouldn't have borders -->

    <div class="ui basic right aligned segment"> ... </div><!-- Fixed: basic segment shouldn't have borders -->
</div>
```