### PR TITLE
[Dropdown] Add new hideDividers option

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -71,6 +71,7 @@ $.fn.dropdown = function(parameters) {
 
         $menu           = $module.children(selector.menu),
         $item           = $menu.find(selector.item),
+        $divider        = $item.siblings(selector.divider),
 
         activated       = false,
         itemActivated   = false,
@@ -384,7 +385,8 @@ $.fn.dropdown = function(parameters) {
           },
           menu: function(values) {
             $menu.html( templates.menu(values, fields));
-            $item = $menu.find(selector.item);
+            $item    = $menu.find(selector.item);
+            $divider = $item.siblings(selector.divider);
           },
           reference: function() {
             module.debug('Dropdown behavior was called on select, replacing with closest dropdown');
@@ -411,7 +413,8 @@ $.fn.dropdown = function(parameters) {
         },
 
         refreshItems: function() {
-          $item = $menu.find(selector.item);
+          $item    = $menu.find(selector.item);
+          $divider = $item.siblings(selector.divider);
         },
 
         refreshSelectors: function() {
@@ -426,6 +429,7 @@ $.fn.dropdown = function(parameters) {
           ;
           $menu    = $module.children(selector.menu);
           $item    = $menu.find(selector.item);
+          $divider = $item.siblings(selector.divider);
         },
 
         refreshData: function() {
@@ -833,6 +837,30 @@ $.fn.dropdown = function(parameters) {
               .not(results)
               .addClass(className.filtered)
             ;
+          }
+
+          if(!module.has.query()) {
+            $divider
+              .removeClass(className.hidden);
+          } else if(settings.hideDividers === true) {
+            $divider
+              .addClass(className.hidden);
+          } else if(settings.hideDividers === 'empty') {
+            $divider
+              .removeClass(className.hidden)
+              .filter(function() {
+                // First find the last divider in this divider group
+                // Dividers which are direct siblings are considered a group
+                var lastDivider = $(this).nextUntil(selector.item);
+
+                return (lastDivider.length ? lastDivider : $(this))
+                // Count all non-filtered items until the next divider (or end of the dropdown)
+                  .nextUntil(selector.divider)
+                  .filter(selector.item + ":not(." + className.filtered + ")")
+                  // Hide divider if no items are found
+                  .length === 0;
+              })
+              .addClass(className.hidden);
           }
         },
 
@@ -2822,6 +2850,9 @@ $.fn.dropdown = function(parameters) {
             else {
               $item.removeClass(className.filtered);
             }
+            if(settings.hideDividers) {
+              $divider.removeClass(className.hidden);
+            }
             module.remove.empty();
           },
           optionValue: function(value) {
@@ -3706,6 +3737,7 @@ $.fn.dropdown.settings = {
 
   match                  : 'both',     // what to match against with search selection (both, text, or label)
   fullTextSearch         : false,      // search anywhere in value (set to 'exact' to require exact matches)
+  hideDividers           : false,      // Whether to hide any divider elements (specified in selector.divider) that are sibling to any items when searched (set to true will hide all dividers, set to 'empty' will hide them when they are not followed by a visible item)
 
   placeholder            : 'auto',     // whether to convert blank <select> values to placeholder text
   preserveHTML           : true,       // preserve html when selecting value
@@ -3822,6 +3854,7 @@ $.fn.dropdown.settings = {
 
   selector : {
     addition     : '.addition',
+    divider      : '.divider, .header',
     dropdown     : '.ui.dropdown',
     hidden       : '.hidden',
     icon         : '> .dropdown.icon',


### PR DESCRIPTION
Dividers are siblings of ".item" elements and mach the divider selector (.header, .divider)

This option takes following values:
- **false**   => Same behavior as before
![false](https://user-images.githubusercontent.com/5517677/41559557-a815ac44-7344-11e8-908c-c0513c43bf6b.gif)
- **true**    => hide all dividers
![true](https://user-images.githubusercontent.com/5517677/41559560-ac485ece-7344-11e8-9ece-b7b2b0246216.gif)
- **'empty'** => hide all dividers if they are not followed by a visible item (direct divider siblings are treated as a group)
![empty](https://user-images.githubusercontent.com/5517677/41559566-afc2d43a-7344-11e8-980a-addad8275116.gif)

Fixes Semantic-Org/Semantic-UI#6173