### PR TITLE
[Dropdown] Add clear icon in single selection mode

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -64,6 +64,7 @@ $.fn.dropdown = function(parameters) {
         $sizer          = $module.find(selector.sizer),
         $input          = $module.find(selector.input),
         $icon           = $module.find(selector.icon),
+        $clear          = $module.find(selector.clearIcon),
 
         $combo = ($module.prev().find(selector.text).length > 0)
           ? $module.prev().find(selector.text)
@@ -320,6 +321,13 @@ $.fn.dropdown = function(parameters) {
             }
             if( !module.has.menu() ) {
               module.create.menu();
+            }
+            if ( !module.is.multiple() && module.is.selection() && module.is.clearable() && !module.has.clearItem() ) {
+              module.verbose('Adding clear icon');
+              $clear = $('<i />')
+                .addClass('remove icon')
+                .insertBefore($text)
+              ;
             }
             if( module.is.search() && !module.has.search() ) {
               module.verbose('Adding search input');
@@ -591,6 +599,7 @@ $.fn.dropdown = function(parameters) {
                 .on('mousedown' + eventNamespace, selector.menu,   module.event.menu.mousedown)
                 .on('mouseup'   + eventNamespace, selector.menu,   module.event.menu.mouseup)
                 .on('click'     + eventNamespace, selector.icon,   module.event.icon.click)
+                .on('click'     + eventNamespace, selector.clearIcon, module.event.clearIcon.click)
                 .on('focus'     + eventNamespace, selector.search, module.event.search.focus)
                 .on('click'     + eventNamespace, selector.search, module.event.search.focus)
                 .on('blur'      + eventNamespace, selector.search, module.event.search.blur)
@@ -606,6 +615,7 @@ $.fn.dropdown = function(parameters) {
               if(settings.on == 'click') {
                 $module
                   .on('click' + eventNamespace, selector.icon, module.event.icon.click)
+                  .on('click' + eventNamespace, selector.clearIcon, module.event.clearIcon.click)
                   .on('click' + eventNamespace, module.event.test.toggle)
                 ;
               }
@@ -1006,6 +1016,16 @@ $.fn.dropdown = function(parameters) {
                 }
               }
               willRefocus = false;
+            }
+          },
+          clearIcon: {
+            click: function(event) {
+              module.clear();
+              if(module.is.searchSelection()) {
+                module.remove.searchTerm();
+              }
+              module.hide();
+              event.stopPropagation();
             }
           },
           icon: {
@@ -2997,6 +3017,9 @@ $.fn.dropdown = function(parameters) {
           menuSearch: function() {
             return (module.has.search() && $search.closest($menu).length > 0);
           },
+          clearItem: function() {
+            return ($clear.length > 0);
+          },
           search: function() {
             return ($search.length > 0);
           },
@@ -3130,6 +3153,9 @@ $.fn.dropdown = function(parameters) {
           leftward: function($subMenu) {
             var $selectedMenu = $subMenu || $menu;
             return $selectedMenu.hasClass(className.leftward);
+          },
+          clearable: function() {
+            return $module.hasClass(className.clearable);
           },
           disabled: function() {
             return $module.hasClass(className.disabled);
@@ -3822,7 +3848,8 @@ $.fn.dropdown.settings = {
     search       : 'input.search, .menu > .search > input, .menu input.search',
     sizer        : '> input.sizer',
     text         : '> .text:not(.icon)',
-    unselectable : '.disabled, .filtered'
+    unselectable : '.disabled, .filtered',
+    clearIcon    : '> .remove.icon'
   },
 
   className : {
@@ -3847,7 +3874,8 @@ $.fn.dropdown.settings = {
     selection   : 'selection',
     upward      : 'upward',
     leftward    : 'left',
-    visible     : 'visible'
+    visible     : 'visible',
+    clearable   : 'clearable'
   }
 
 };

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -631,6 +631,24 @@ select.ui.dropdown {
   }
 }
 
+/* Clearable Selection */
+.ui.dropdown .remove.icon {
+  font-size: @dropdownIconSize;
+  margin: @dropdownIconMargin;
+  padding: 0;
+  right: 2.5em;
+  top: auto;
+  position: absolute;
+  opacity: 0.6;
+  z-index: 3;
+}
+
+.ui.dropdown input[value=''] ~ .remove.icon,
+.ui.dropdown input:not([value]) ~ .remove.icon,
+.ui.dropdown.loading .remove.icon {
+  display: none;
+}
+
 /*--------------
     Multiple
 ---------------*/


### PR DESCRIPTION
Add the ability to clear a single selection dropdown thanks to the `clearable` class.

Related SUI issue: Semantic-Org/Semantic-UI#3635.
