### PR TITLE
 [Tab] Last tab should still have a bottom margin

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -105,6 +105,10 @@
   padding: @padding;
 }
 
+/* Tab */
+.ui.segment.tab:last-child {
+  margin-bottom: @verticalMargin;
+}
 
 /*******************************
              Types


### PR DESCRIPTION
Segments used in tabs should always have the same margin.

Closes issue Semantic-Org/Semantic-UI#6461