### PR TITLE
[Modal] Fullscreen Modals since 2.3.0 regression in Safari

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -27,6 +27,8 @@
   z-index: @zIndex;
   text-align: left;
 
+  position: relative;
+
   background: @background;
   border: @border;
   box-shadow: @boxShadow;


### PR DESCRIPTION
This fixes the absolutely positioned close icon inside the modal

Closes Semantic-Org/Semantic-UI#6251