### PR TITLE
[Label] :ActiveHover is not a valid selector error #5908

### DIFF
--- a/src/definitions/elements/label.less
+++ b/src/definitions/elements/label.less
@@ -505,8 +505,8 @@ a.ui.active.label:hover {
   background-image: @labelActiveHoverBackgroundImage;
   color: @labelActiveHoverTextColor;
 }
-.ui.labels a.active.label:ActiveHover:before,
-a.ui.active.label:ActiveHover:before {
+.ui.labels a.active.label:hover:before,
+a.ui.active.label:hover:before {
   background-color: @labelActiveHoverBackgroundColor;
   background-image: @labelActiveHoverBackgroundImage;
   color: @labelActiveHoverTextColor;


### PR DESCRIPTION
Fixes odd background color variation in tag labels:
![image](https://user-images.githubusercontent.com/5517677/42208957-c2d38636-7ead-11e8-9005-7e0a256122b1.png)

Closes Semantic-Org/Semantic-UI#5908