### PR TITLE
[Docs] build error on new node version

### DIFF
--- a/tasks/docs/build.js
+++ b/tasks/docs/build.js
@@ -80,7 +80,7 @@ module.exports = function(callback) {
   gulp.src(config.paths.template.eco + globs.eco)
     .pipe(map(metadata.parser))
     .on('end', function() {
-      fs.writeFile(output.metadata + '/metadata.json', JSON.stringify(metadata.result, null, 2));
+      fs.writeFile(output.metadata + '/metadata.json', JSON.stringify(metadata.result, null, 2), new Function());
     })
   ;
 


### PR DESCRIPTION
Fixes #54

Latest node version errors and exits script because fs doesn't contain a callback.

I added a blank function therefore it doesn't complain