### PR TITLE
Fix the dropdown pointer that still remains after dropdown menu is collapsed

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1239,7 +1239,7 @@ select.ui.dropdown {
   border-radius: @pointingMenuBorderRadius;
 }
 
-.ui.pointing.dropdown > .menu:after {
+.ui.pointing.dropdown > .menu:not(.hidden):after {
   display: block;
   position: absolute;
   pointer-events: none;
@@ -1254,7 +1254,7 @@ select.ui.dropdown {
   z-index: @pointingArrowZIndex;
 }
 
-.ui.pointing.dropdown > .menu:after {
+.ui.pointing.dropdown > .menu:not(.hidden):after {
   top: @pointingArrowOffset;
   left: 50%;
   margin: 0em 0em 0em @pointingArrowOffset;


### PR DESCRIPTION
A little background...

The PR Semantic-Org/Semantic-UI#4211 add a left class to the dropdown menu under some circumstances. That left class trigger some CSS items that broke the dropdown display... This PR cannot be reverted, so we must find another way to fix the issue... and here it is !

Fixes Semantic-Org/Semantic-UI#6491.