### PR TITLE
Fix incorrect top attached header top margin

### DIFF
--- a/src/definitions/elements/header.less
+++ b/src/definitions/elements/header.less
@@ -692,28 +692,31 @@ a.ui.inverted.grey.header:hover {
 .ui.attached.header {
   background: @attachedBackground;
   padding: @attachedVerticalPadding @attachedHorizontalPadding;
+  margin-top: 0em;
+  margin-bottom: 0em;
   margin-left: @attachedOffset;
   margin-right: @attachedOffset;
   box-shadow: @attachedBoxShadow;
   border: @attachedBorder;
+  border-radius: 0em;
 }
 .ui.attached.block.header {
   background: @blockBackground;
 }
 
 .ui.attached:not(.top):not(.bottom).header {
-  margin-top: 0em;
-  margin-bottom: 0em;
   border-top: none;
-  border-radius: 0em;
 }
-.ui.top.attached.header {
-  margin-bottom: 0em;
+.ui.top.attached.header:not(:first-child) {
+  border-top: none;
+}
+.ui.top.attached.header:first-child {
   border-radius: @attachedBorderRadius @attachedBorderRadius 0em 0em;
 }
 .ui.bottom.attached.header {
-  margin-top: 0em;
   border-top: none;
+}
+.ui.bottom.attached.header:last-child {
   border-radius: 0em 0em @attachedBorderRadius @attachedBorderRadius;
 }
 


### PR DESCRIPTION
### Description
This PR fix the incorrect top attached header top margin which was negative.

Before:
![ef232077b2eef0b5bd647f293365a935.png](https://tof.cx/images/2018/07/26/ef232077b2eef0b5bd647f293365a935.png)

After:
![797901103121e1253ae96ff81251df10.png](https://tof.cx/images/2018/07/26/797901103121e1253ae96ff81251df10.png)

**Bonus point**
It also add the ability to stack many top or bottom attached headers without broke everything !

```html
<div class="ui top attached header">Demo</div>
<div class="ui top attached header">Demo</div>
<div class="ui attached header">Demo</div>
<div class="ui bottom attached header">Demo</div>
<div class="ui bottom attached header">Demo</div>
```
Before:
![5438ca09635302b50364e4c240d9d4e3.png](https://tof.cx/images/2018/07/26/5438ca09635302b50364e4c240d9d4e3.png)

After:
![3de8a0758b228542ee96e50c65334162.png](https://tof.cx/images/2018/07/26/3de8a0758b228542ee96e50c65334162.png)

### Closed Issues
Semantic-Org/Semantic-UI#5436
Semantic-Org/Semantic-UI#5462
