### PR TITLE
Fixed textarea having wrong font family

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -136,7 +136,6 @@
   tap-highlight-color:  rgba(255, 255, 255, 0);
 
   padding: @textAreaPadding;
-  font-size: @textAreaFontSize;
   background: @textAreaBackground;
   border: @textAreaBorder;
   outline: none;
@@ -145,6 +144,7 @@
   box-shadow: @inputBoxShadow;
   transition: @textAreaTransition;
   font-size: @textAreaFontSize;
+  font-family: @inputFont;
   line-height: @textAreaLineHeight;
   resize: @textAreaResize;
 }


### PR DESCRIPTION
Added `@inputFont` to the textarea so it now uses the theme font family. Also removed duplicate `font-size`.

### Closed Issues
https://github.com/Semantic-Org/Semantic-UI/issues/5546