### PR TITLE
Disabled rating

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,9 @@
 - Calendar Component
 - Range Slider Component
 
+**Enhancements**
+- **Rating** - Add the ability to start a disabled rating trough the `disabled` class
+
 ### Version 2.4.3 - July 9, 2018
 
 **Bugs**

--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -67,7 +67,7 @@ $.fn.rating = function(parameters) {
             module.setup.layout();
           }
 
-          if(settings.interactive) {
+          if(settings.interactive && !module.is.disabled()) {
             module.enable();
           }
           else {
@@ -204,6 +204,9 @@ $.fn.rating = function(parameters) {
         is: {
           initialLoad: function() {
             return initialLoad;
+          },
+          disabled: function() {
+            return $module.hasClass(className.disabled);
           }
         },
 


### PR DESCRIPTION
Rating couldn't be started read-only with the disabled class. This PR add the ability to do so.