### PR TITLE
fix(accordion): Invert active condition

### DIFF
--- a/src/definitions/modules/accordion.less
+++ b/src/definitions/modules/accordion.less
@@ -44,12 +44,6 @@
   color: @titleColor;
 }
 
-/* Content */
-.ui.accordion .title ~ .content,
-.ui.accordion .accordion .title ~ .content {
-  display: none;
-}
-
 /* Default Styling */
 .ui.accordion:not(.styled) .title ~ .content:not(.ui),
 .ui.accordion:not(.styled) .accordion .title ~ .content:not(.ui) {
@@ -186,12 +180,12 @@
 *******************************/
 
 /*--------------
-     Active
+   Not Active
 ---------------*/
 
-.ui.accordion .active.content,
-.ui.accordion .accordion .active.content {
-  display: block;
+.ui.accordion .content:not(.active),
+.ui.accordion .accordion .content:not(.active) {
+  display: none;
 }
 
 /*******************************


### PR DESCRIPTION
Instead of setting the default display to 'none' and active display to 'block', we only set the the display to 'none' when it's `:not(.active)`

Fixes Semantic-Org/Semantic-UI#6351