### PR TITLE
[Step] Fix the bad step count in a segment

### DIFF
--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -185,7 +185,7 @@
   display: block;
   position: static;
   text-align: center;
-  content: counters(ordered, ".");
+  content: counter(ordered);
   align-self: @iconAlign;
   margin-right: @iconDistance;
   font-size: @iconSize;


### PR DESCRIPTION
Before:
[![22b6e3e244f87729f3e1fbd4c8ced087.md.png](https://tof.cx/images/2018/08/16/22b6e3e244f87729f3e1fbd4c8ced087.md.png)](https://tof.cx/image/ehVO1)

After:
[![aec340832592ab9a5794b2ae5ab93aa2.md.png](https://tof.cx/images/2018/08/16/aec340832592ab9a5794b2ae5ab93aa2.md.png)](https://tof.cx/image/ehk9A)

Test case:
```html
<div class="ui ordered steps">
  <div class="completed step">
    <div class="content">
      <div class="title">Shipping</div>
      <div class="description">Choose your shipping options</div>
    </div>
  </div>
  <div class="completed step">
    <div class="content">
      <div class="title">Billing</div>
      <div class="description">Enter billing information</div>
    </div>
  </div>
  <div class="active step">
    <div class="content">
      <div class="title">Confirm Order</div>
      <div class="description">Verify order details</div>
    </div>
  </div>
</div>

<div class="ui segment">
  <div class="ui ordered steps">
    <div class="completed step">
      <div class="content">
        <div class="title">Shipping</div>
        <div class="description">Choose your shipping options</div>
      </div>
    </div>
    <div class="completed step">
      <div class="content">
        <div class="title">Billing</div>
        <div class="description">Enter billing information</div>
      </div>
    </div>
    <div class="active step">
      <div class="content">
        <div class="title">Confirm Order</div>
        <div class="description">Verify order details</div>
      </div>
    </div>
  </div>
</div>
```